### PR TITLE
Fixing beam search issue 

### DIFF
--- a/experiments/run-big-bench.py
+++ b/experiments/run-big-bench.py
@@ -165,7 +165,7 @@ def compute_metrics(
             end = time.time()
             latencies.append(end - start)
             top_k_indices.append(indices[0])
-
+            
     querying_time = sum(latencies)
     metrics = {}
     if "qps" in requested_metrics:

--- a/experiments/run-big-bench.py
+++ b/experiments/run-big-bench.py
@@ -157,7 +157,6 @@ def compute_metrics(
             end = time.time()
             latencies.append(end - start)
             top_k_indices.append(indices)
-
     else:
         index.set_ef(ef_search)
         for query in queries:
@@ -288,6 +287,7 @@ def train_index(
         # using the HNSW base layer graph. We do not use the ef-construction parameter since
         # it's assumed to have been used when building the HNSW base layer.
         index.allocate_nodes(data=train_dataset).build_graph_links()
+        os.remove(hnsw_base_layer_filename)
 
     else:
         index = flatnav.index.index_factory(
@@ -295,7 +295,7 @@ def train_index(
             dim=dim,
             dataset_size=dataset_size,
             max_edges_per_node=max_edges_per_node,
-            verbose=True,
+            verbose=False,
         )
         index.set_num_threads(num_build_threads)
 

--- a/flatnav/Index.h
+++ b/flatnav/Index.h
@@ -308,9 +308,10 @@ public:
                                    int ef_search,
                                    int num_initializations = 100) {
     node_id_t entry_node = initializeSearch(query, num_initializations);
-    PriorityQueue neighbors = beamSearch(/* query = */ query,
-                                         /* entry_node = */ entry_node,
-                                         /* buffer_size = */ ef_search);
+    PriorityQueue neighbors =
+        beamSearch(/* query = */ query,
+                   /* entry_node = */ entry_node,
+                   /* buffer_size = */ std::max(ef_search, K));
     auto size = neighbors.size();
     std::vector<dist_label_t> results;
     results.reserve(size);
@@ -501,7 +502,6 @@ private:
     PriorityQueue candidates;
 
     auto *visited_set = _visited_set_pool->pollAvailableSet();
-    uint8_t visited_set_mark = visited_set->getMark();
     visited_set->clear();
 
     float dist =
@@ -572,7 +572,6 @@ private:
 #ifdef USE_SSE
         _mm_prefetch(getNodeData(candidates.top().second), _MM_HINT_T0);
 #endif
-
         if (neighbors.size() > buffer_size) {
           neighbors.pop();
         }

--- a/flatnav/Index.h
+++ b/flatnav/Index.h
@@ -61,6 +61,7 @@ template <typename dist_t, typename label_t> class Index {
   VisitedSetPool *_visited_set_pool;
   std::vector<std::mutex> _node_links_mutexes;
   std::optional<std::vector<std::vector<uint32_t>>> _outdegree_table;
+  bool _verbose;
 
   template <typename Archive> void serialize(Archive &archive) {
     archive(_M, _data_size_bytes, _node_size_bytes, _max_node_count,
@@ -82,13 +83,13 @@ public:
    * @param max_edges_per_node  The maximum number of links per node.
    */
   Index(std::shared_ptr<DistanceInterface<dist_t>> dist, int dataset_size,
-        int max_edges_per_node)
+        int max_edges_per_node, bool verbose = false)
       : _M(max_edges_per_node), _max_node_count(dataset_size),
         _cur_num_nodes(0), _distance(dist), _num_threads(1),
         _visited_set_pool(new VisitedSetPool(
             /* initial_pool_size = */ 1,
             /* num_elements = */ dataset_size)),
-        _node_links_mutexes(dataset_size) {
+        _node_links_mutexes(dataset_size), _verbose(verbose) {
 
     // Get the size in bytes of the _node_links_mutexes vector.
     size_t mutexes_size_bytes = _node_links_mutexes.size() * sizeof(std::mutex);
@@ -113,8 +114,9 @@ public:
    */
 
   Index(std::shared_ptr<DistanceInterface<dist_t>> dist,
-        const std::string &mtx_filename)
-      : _cur_num_nodes(0), _distance(std::move(dist)), _num_threads(1) {
+        const std::string &mtx_filename, bool verbose = false)
+      : _cur_num_nodes(0), _distance(std::move(dist)), _num_threads(1),
+        _verbose(verbose) {
     auto mtx_graph =
         flatnav::util::loadGraphFromMatrixMarket(mtx_filename.c_str());
     _outdegree_table = std::move(mtx_graph.adjacency_list);
@@ -312,6 +314,11 @@ public:
                                          /* entry_node = */ entry_node,
                                          /* buffer_size = */ ef_search);
     auto size = neighbors.size();
+    if (_verbose) {
+      std::cout << "Beam search returned " << size << " neighbors.\n"
+                << std::flush;
+    }
+
     std::vector<dist_label_t> results;
     results.reserve(size);
     while (!neighbors.empty()) {
@@ -421,6 +428,8 @@ public:
     }
   }
 
+  inline void setVerbose(bool verbose) { _verbose = verbose; }
+
   inline uint32_t getNumThreads() const { return _num_threads; }
 
   inline size_t maxEdgesPerNode() const { return _M; }
@@ -501,6 +510,15 @@ private:
     PriorityQueue candidates;
 
     auto *visited_set = _visited_set_pool->pollAvailableSet();
+    uint8_t visited_set_mark = visited_set->getMark();
+
+    if (_verbose) {
+      uint8_t table_value = visited_set->getTableValue(entry_node);
+      std::cout << "Visited set mark: " << (int)visited_set_mark << "\n"
+                << "Table value for entry node: " << (int)table_value << "\n"
+                << std::flush;
+    }
+
     visited_set->clear();
 
     float dist =
@@ -512,9 +530,55 @@ private:
     neighbors.emplace(dist, entry_node);
     visited_set->insert(entry_node);
 
+    visited_set_mark = visited_set->getMark();
+    if (_verbose) {
+      uint8_t table_value = visited_set->getTableValue(entry_node);
+      std::cout << "Visited set mark: " << (int)visited_set_mark << "\n"
+                << "Table value for entry node: " << (int)table_value << "\n"
+                << std::flush;
+    }
+
+    // if (_verbose) {
+    //   // Print entry point node and distance to the query.
+    //   std::cout << "Entry node: " << entry_node << " with distance " << dist
+    //             << " to the query.\n"
+    //             << std::flush;
+    // }
+
     while (!candidates.empty()) {
       dist_node_t d_node = candidates.top();
-      if ((-d_node.first) > max_dist) {
+
+      // if (_verbose) {
+      //   // Print the node ID we're processing and the distance to teh query
+      //   as
+      //   // well as the distance to the query from the entry node.
+      //   std::cout << "Processing node " << d_node.second << " with distance "
+      //             << -d_node.first << " to the query and " << dist
+      //             << " to the entry node.\n"
+      //             << std::flush;
+
+      //   // Print all neighbors for this node.
+      //   auto *links = getNodeLinks(d_node.second);
+      //   for (size_t i = 0; i < _M; i++) {
+      //     if (d_node.second != links[i]) {
+      //       std::cout << "Neighbor " << i << " of node " << d_node.second
+      //                 << " is " << links[i] << "\n"
+      //                 << std::flush;
+      //     }
+      //   }
+      // }
+
+      if ((-d_node.first) > max_dist && neighbors.size() >= buffer_size) {
+        // Print out all the d_node.first, max_dist, and neighbors.size()
+        // values.
+        // if (_verbose) {
+        //   std::cout << "Breaking out of beam search with distance "
+        //             << -d_node.first << " and max_dist " << max_dist
+        //             << " and neighbors size " << neighbors.size() << ".\n"
+        //             << std::flush;
+        //   std::cout << "Data node id: " << d_node.second << "\n" <<
+        //   std::flush;
+        // }
         break;
       }
       candidates.pop();
@@ -522,7 +586,7 @@ private:
       processCandidateNode(
           /* query = */ query, /* node = */ d_node.second,
           /* max_dist = */ max_dist, /* buffer_size = */ buffer_size,
-          /* visited_nodes = */ visited_set,
+          /* visited_set = */ visited_set,
           /* neighbors = */ neighbors, /* candidates = */ candidates);
     }
 
@@ -557,6 +621,17 @@ private:
           visited_set->isVisited(/* num = */ neighbor_node_id);
 
       if (neighbor_is_visited) {
+        if (_verbose) {
+          uint8_t table_value = visited_set->getTableValue(neighbor_node_id);
+          uint8_t visited_set_mark = visited_set->getMark();
+
+          // Print out the visited set mark and the table value for the
+          // neighbor node.
+          std::cout << "Neighbor " << neighbor_node_id << " is visited with "
+                    << "table value " << (int)table_value << " and visited set "
+                    << "mark " << (int)visited_set_mark << ".\n"
+                    << std::flush;
+        }
         continue;
       }
       visited_set->insert(/* num = */ neighbor_node_id);
@@ -565,6 +640,14 @@ private:
                                  /* asymmetric = */ true);
 
       if (neighbors.size() < buffer_size || dist < max_dist) {
+        // if (_verbose) {
+        //   std::cout << "Adding neighbor " << neighbor_node_id << " with "
+        //             << "distance " << dist << " to the query.\n"
+        //             << std::flush;
+        //   std::cout << "Size of neighbors set: " << neighbors.size() << "\n"
+        //             << std::flush;
+        // }
+
         candidates.emplace(-dist, neighbor_node_id);
         neighbors.emplace(dist, neighbor_node_id);
 #ifdef USE_SSE

--- a/flatnav/util/VisitedSetPool.h
+++ b/flatnav/util/VisitedSetPool.h
@@ -36,10 +36,23 @@ public:
 
   inline uint32_t size() const { return _table_size; }
 
-  inline void clear() { _mark++; }
+  inline void clear() {
+    _mark++;
+    // If we overflow (i.e., _mark equals to the maximum value of uint8_t), we
+    // reset the visited set to 0 and start over with mark 0.
+    // auto max_uint8_t = std::numeric_limits<uint8_t>::max();
+    // if (_mark == max_uint8_t) {
+    //   std::memset(_table, 0, _table_size);
+    //   _mark = 1;
+    // }
+  }
 
   inline bool isVisited(const uint32_t num) const {
     return _table[num] == _mark;
+  }
+
+  inline uint8_t getTableValue(const uint32_t num) const {
+    return _table[num];
   }
 
   ~VisitedSet() { delete[] _table; }

--- a/flatnav/util/VisitedSetPool.h
+++ b/flatnav/util/VisitedSetPool.h
@@ -19,7 +19,7 @@ private:
   uint32_t _table_size;
 
 public:
-  VisitedSet(const uint32_t size) : _mark(0), _table_size(size) {
+  VisitedSet(const uint32_t size) : _mark(1), _table_size(size) {
     // initialize values to 0
     _table = new uint8_t[_table_size]();
   }
@@ -38,21 +38,14 @@ public:
 
   inline void clear() {
     _mark++;
-    // If we overflow (i.e., _mark equals to the maximum value of uint8_t), we
-    // reset the visited set to 0 and start over with mark 0.
-    // auto max_uint8_t = std::numeric_limits<uint8_t>::max();
-    // if (_mark == max_uint8_t) {
-    //   std::memset(_table, 0, _table_size);
-    //   _mark = 1;
-    // }
+    if (_mark == 0) {
+      std::memset(_table, 0, _table_size);
+      _mark = 1;
+    }
   }
 
   inline bool isVisited(const uint32_t num) const {
     return _table[num] == _mark;
-  }
-
-  inline uint8_t getTableValue(const uint32_t num) const {
-    return _table[num];
   }
 
   ~VisitedSet() { delete[] _table; }

--- a/flatnav_python/python_bindings.cpp
+++ b/flatnav_python/python_bindings.cpp
@@ -221,7 +221,14 @@ public:
             /* query = */ (const void *)queries.data(query_index), /* K = */ K,
             /* ef_search = */ ef_search,
             /* num_initializations = */ num_initializations);
-            
+
+        if (top_k.size() != K) {
+          throw std::runtime_error("Search did not return the expected number "
+                                   "of results. Expected " +
+                                   std::to_string(K) + " but got " +
+                                   std::to_string(top_k.size()) + ".");
+        }
+
         for (size_t i = 0; i < top_k.size(); i++) {
           distances[query_index * K + i] = top_k[i].first;
           results[query_index * K + i] = top_k[i].second;

--- a/flatnav_python/python_bindings.cpp
+++ b/flatnav_python/python_bindings.cpp
@@ -154,7 +154,7 @@ public:
     }
   }
 
-  DistancesLabelsPair search_single(
+  DistancesLabelsPair searchSingle(
       const py::array_t<float, py::array::c_style | py::array::forcecast>
           &query,
       int K, int ef_search, int num_initializations = 100) {
@@ -167,6 +167,12 @@ public:
         /* query = */ (const void *)query.data(0), /* K = */ K,
         /* ef_search = */ ef_search,
         /* num_initializations = */ num_initializations);
+
+    if (top_k.size() != K) {
+      throw std::runtime_error(
+          "Search did not return the expected number of results. Expected " +
+          std::to_string(K) + " but got " + std::to_string(top_k.size()) + ".");
+    }
 
     label_t *labels = new label_t[K];
     float *distances = new float[K];
@@ -216,6 +222,12 @@ public:
             /* ef_search = */ ef_search,
             /* num_initializations = */ num_initializations);
 
+        if (top_k.size() != K) {
+          throw std::runtime_error("Search did not return the expected number "
+                                   "of results. Expected " +
+                                   std::to_string(K) + " but got " +
+                                   std::to_string(top_k.size()) + ".");
+        }
         for (size_t i = 0; i < top_k.size(); i++) {
           distances[query_index * K + i] = top_k[i].first;
           results[query_index * K + i] = top_k[i].second;
@@ -291,7 +303,7 @@ void bindIndexMethods(
            "grpah. When using this method, you should invoke "
            "`build_graph_links` explicity. NOTE: In most cases you should not "
            "need to use this method.")
-      .def("search_single", &IndexType::search_single, py::arg("query"),
+      .def("search_single", &IndexType::searchSingle, py::arg("query"),
            py::arg("K"), py::arg("ef_search"),
            py::arg("num_initializations") = 100,
            "Return top `K` closest data points for the given `query`. The "

--- a/flatnav_python/python_bindings.cpp
+++ b/flatnav_python/python_bindings.cpp
@@ -221,13 +221,7 @@ public:
             /* query = */ (const void *)queries.data(query_index), /* K = */ K,
             /* ef_search = */ ef_search,
             /* num_initializations = */ num_initializations);
-
-        if (top_k.size() != K) {
-          throw std::runtime_error("Search did not return the expected number "
-                                   "of results. Expected " +
-                                   std::to_string(K) + " but got " +
-                                   std::to_string(top_k.size()) + ".");
-        }
+            
         for (size_t i = 0; i < top_k.size(); i++) {
           distances[query_index * K + i] = top_k[i].first;
           results[query_index * K + i] = top_k[i].second;


### PR DESCRIPTION
## Issue Report 

In a previous [PR](https://github.com/BlaiseMuhirwa/flatnav-experimental/pull/33), I added a change to verify that calls to `search()` return exactly `k` results as one would expect. The interesting thing is that in some cases, we would get the following error:

```
Traceback (most recent call last):
  File "/root/flatnavlib/experiments/run-big-bench.py", line 156, in compute_metrics
    _, indices = index.search_single(
                 ^^^^^^^^^^^^^^^^^^^^
RuntimeError: Search did not return the expected number of results. Expected 100 but got 1.
Traceback (most recent call last):
  File "/root/flatnavlib/experiments/run-big-bench.py", line 605, in <module>
    run_experiment()
  File "/root/flatnavlib/experiments/run-big-bench.py", line 558, in run_experiment
    main(
  File "/root/flatnavlib/experiments/run-big-bench.py", line 382, in main
    compute_metrics(
  File "/root/flatnavlib/experiments/run-big-bench.py", line 156, in compute_metrics
    _, indices = index.search_single(
                 ^^^^^^^^^^^^^^^^^^^^
RuntimeError: Search did not return the expected number of results. Expected 100 but got 1.
make: *** [Makefile:15: fashion-mnist-bench-flatnav] Error 1
```

This suggested that something was wrong with our beam search implementation, so it was reason to figure out why. I cross-referenced HNSWlib's implementation and couldn't find an algorithmic error since our beamSearch implementation is pretty much similar to their searchBaseLayer implementation. 

## Detective work: RCA

To figure out the root cause of the issue, I looked at all query ID's for which this exception occurs. For one dataset, there were a few such instances, one of which was query with ID 5728. Here is what happened during the execution of `search_single` for this query:

* `search_single` invokes the C++ search method in which we call beam search. 
* Search first finds the entry point node, which is node with ID 15600. 
* Node 15600 is added to the priority queue of candidates to return.
* Beam search finds that every single neighbor of node 15600 is visited, so it exits without finding any other node to add to the returned list, hence `Expected 100 but got 1`. 

### Why does beam search "think" every neighbor is already visited? 

This is where the bug was. Each query should be processed independently of others, so it doesn't make sense to find other nodes visited right at the start of beam search. This implied that there was shared state between queries that ought not to be shared. So, I dug deeper and observed the following: 

* Every query for which this exception was raised had an entry node with very few outgoing arcs. In particular, entry node 15600 had 7 outgoing arcs out of 32 total edges (the rest are self-loops). 
* Every neighbor of this node was already visited. This implied to me that there must be something wrong with our visited list, so I looked at our code for the visited set and visited set pool implementation. 

Here is what I noticed: At the start of beam search, we always "[clear](https://github.com/BlaiseMuhirwa/flatnav-experimental/blob/036328d41327de1b67687dc3e6a0aded2bbcf712/flatnav/Index.h#L504)" out the visited set that we get from the pool (in the single-threaded context, this is just one set that is shared by all queries sequentially). The goal of this operation is to make sure that we start from a clean slate for every new query that we process so that when we run `visited_set->isVisisted(node)` we're guaranteed to not be affected by the previous query that we processed -- except that this is not what was happening in certain cases. So, the problem had to do with the implementation for "clearing" out the visited set. 

### Digging even deeper

Note that in our visited set implementation, we use a [marker](https://github.com/BlaiseMuhirwa/flatnav-experimental/blob/036328d41327de1b67687dc3e6a0aded2bbcf712/flatnav/util/VisitedSetPool.h#L17) of type `uint8_t` and keep incrementing it for new queries. There is one situation where this is dangerous if not handled with care. Consider node with ID 15600 and its neighborhood. What was happening is that this marker was incremented beyond 255, so it had to start all over again from 0 (increasing it by 1 will cause an overflow, and the result will wrap around to 0). During search from other queries, the underlying visited set [table](https://github.com/BlaiseMuhirwa/flatnav-experimental/blob/036328d41327de1b67687dc3e6a0aded2bbcf712/flatnav/util/VisitedSetPool.h#L18) of type `uint8_t*` was modified and we got in a situation where 

* `_table[15600]` was marked 97 before running beam search on query 5728 (the ID of the query itself here doesn't matter). 
* `_mark` was marked 96 for node 15600 and its neighbors. This shouldn't happen since the idea of the "clear" method is to keep incrementing the marker so that a node that is visited gets marked with the new marker value. 
* When we called `_visisted_set->clear()`, the marker was set to 97 for this entry point node and its 7 neighbors. This is what caused the issue. Since the marker and `table[node]` were all 97, every time we checked whether a node is visited, it returned true, which in reality is wrong since we're not supposed to have these nodes as visited before we even explore any node. 

Here is a log output showing the marker value before clearing out the visited set and after clearing it out. It also shows why all nodes were marked as visited. 

```
Visited set mark before clearing set: 96
Table value for entry node: 97
Visited set mark after clearing set: 97
Table value for entry node: 97
Neighbor 10475 is visited with table value 97 and visited set mark 97.
Neighbor 2057 is visited with table value 97 and visited set mark 97.
Neighbor 13576 is visited with table value 97 and visited set mark 97.
Neighbor 4748 is visited with table value 97 and visited set mark 97.
Neighbor 23087 is visited with table value 97 and visited set mark 97.
Neighbor 41767 is visited with table value 97 and visited set mark 97.
Neighbor 54717 is visited with table value 97 and visited set mark 97.
Neighbor 15600 is visited with table value 97 and visited set mark 97.
```

### Fixing the issue

The fix for this is simple. We just need to make sure that `_marker` is always higher than `_table[node]` for any node in the graph. The way to do that is to make sure that when `_marker` exceeds `std::numeric_limits<uint8_t>::max()` aka 255, we reset the `_table` to be all zeros. This is what this pull request does. 

### Fixing the recall issue once and for all

While I was at it, I noticed that the constructor for the explicit set object sets `_marker` to 0 instead of 1. This is problematic because the first time you run beam search on any node, the call to `visited_set->isVisited(node_1)` will return true since this simply checks whether the marker (with value 0 at this time) is equal to the value at `_table[node_1]`, which is also initialized to 0. This means that for all first queries (during construction and search), we always mark them as visited, which prevents us from actually ever exploring their neighborhood correctly. Note that this doesn't affect subsequent queries much because the marker gets incremented correctly thereafter. A direct consequence of the failure to explore the first node as we should accounts for the recall difference we've been observing. Thus, a fix for the recall here is to ensure that the marker is always initialized with a value higher than 0, so setting it to 1 fixes the issue. 

To see the recall fix in action, take a look at the following plot for QPS against recall for SIFT 1M with ef-construction 100, 200 and ef-search 100, 200, 300 with M=32. 

![Screenshot 2024-02-19 at 2 55 56 AM](https://github.com/BlaiseMuhirwa/flatnav-experimental/assets/51985360/745fc53a-6e05-4e31-8ac6-5071451dfe8f)
![Screenshot 2024-02-19 at 2 53 38 AM](https://github.com/BlaiseMuhirwa/flatnav-experimental/assets/51985360/0e38793b-4343-4c2d-9ff2-c3bc8ce35169)


The first plot is what we've been observing before: HNSW was a tiny bit ahead of us. The second plot shows what we get after using this recall fix. 

NOTE: The QPS gap is wider this time because we added prefetching to FlatNav. 







