### PR TITLE
Slightly faster kNN retrieval

### DIFF
--- a/flatnav/Index.h
+++ b/flatnav/Index.h
@@ -313,26 +313,18 @@ public:
                    /* entry_node = */ entry_node,
                    /* buffer_size = */ std::max(ef_search, K));
 
-    std::priority_queue<dist_label_t, std::vector<dist_label_t>> max_heap;
+    while (neighbors.size() > K) {
+      neighbors.pop();
+    }
+    std::vector<dist_label_t> results;
+    results.reserve(neighbors.size());
 
-    while (!neighbors.empty()) {
+    while (neighbors.size() > 0) {
       auto [distance, node_id] = neighbors.top();
-      if (max_heap.size() < K) {
-        max_heap.emplace(distance, *getNodeLabel(node_id));
-      } else if (distance < max_heap.top().first) {
-        max_heap.pop();
-        max_heap.emplace(distance, *getNodeLabel(node_id));
-      }
+      results.emplace_back(distance, *getNodeLabel(node_id));
       neighbors.pop();
     }
 
-    std::vector<dist_label_t> results;
-    results.reserve(max_heap.size());
-    while (!max_heap.empty()) {
-      results.emplace_back(max_heap.top());
-      max_heap.pop();
-    }
-    std::reverse(results.begin(), results.end());
     return results;
   }
 


### PR DESCRIPTION
This avoids having to sort the returned neighbors. This change is the difference between having ~62 QPS vs ~51 QPS for ef-search=5000, ef-cons=300 on nytimes ANN benchmark. Generally, it's a bit faster but not by much.  