### PR TITLE
Refactoring Dataset loader 

### DIFF
--- a/experiments/data_loader.py
+++ b/experiments/data_loader.py
@@ -46,7 +46,7 @@ class DatasetLoader(ABC):
         pass
 
 
-class NPYDatasetLoader(DatasetLoader):
+class NpyDatasetLoader(DatasetLoader):
     def load_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         if self.range:
             start_index, end_index = self.range
@@ -62,9 +62,9 @@ class NPYDatasetLoader(DatasetLoader):
         return train_dataset, queries, ground_truth
 
 
-class BVECDatasetLoader:
+class BvecsDatasetLoader(DatasetLoader):
     """
-    This is adapted from the Matlab code provided by the authors of the SIFT1M dataset.
+    This is adapted from the Matlab code provided by the authors of the SIFT dataset.
     Reference:
         1. http://corpus-texmex.irisa.fr/ivecs_read.m
         2. http://corpus-texmex.irisa.fr/bvecs_read.m
@@ -116,7 +116,7 @@ class BVECDatasetLoader:
     def load_data(self) -> Tuple[np.ndarray]:
         ground_truth = self._read_ivecs_file(self.gtruth_path, self.range)
         # Ground truth has shape (10000, 1000) but we only need the first 100 queries
-        ground_truth = ground_truth[:100]
+        ground_truth = ground_truth[:, 0:100]
 
         train_data = self._read_bvecs_file(self.train_dataset_path, self.range)
         queries_data = self._read_bvecs_file(self.queries_path, self.range)
@@ -124,7 +124,7 @@ class BVECDatasetLoader:
         return train_data, queries_data, ground_truth
 
 
-class FBINDatasetLoader(DatasetLoader):
+class FbinDatasetLoader(DatasetLoader):
     """
     NOTE: This is mostly for loading the DEEP1B dataset.
     Uses numpy's memmap to map the file to memory, which is useful for large files like the DEEP1B dataset.
@@ -207,17 +207,17 @@ class FBINDatasetLoader(DatasetLoader):
 def get_data_loader(**kwargs) -> DatasetLoader:
     """
     Factory function for creating the appropriate dataset loader based on the extension of the training dataset.
-    :param kwargs: Dictionary of parameters. These must correspond to the parameters of the DatasetLoader class.
+    :param kwargs: Dictionary of parameters. These must correspond to the parameters of the DatasetLoader constructor.
     """
     train_dataset_path = kwargs.get("train_dataset_path")
     if not train_dataset_path:
         raise ValueError("The train_dataset_path parameter is required.")
 
     if train_dataset_path.endswith(".npy"):
-        return NPYDatasetLoader(**kwargs)
+        return NpyDatasetLoader(**kwargs)
     elif train_dataset_path.endswith(".bvecs"):
-        return BVECDatasetLoader(**kwargs)
+        return BvecsDatasetLoader(DatasetLoader)(**kwargs)
     elif train_dataset_path.endswith(".fbin"):
-        return FBINDatasetLoader(**kwargs)
+        return FbinDatasetLoader(**kwargs)
 
     raise ValueError("Invalid file extension for the training dataset.")

--- a/experiments/data_loader.py
+++ b/experiments/data_loader.py
@@ -1,0 +1,223 @@
+import numpy as np
+from abc import ABC, abstractmethod
+import os
+from typing import Tuple, List, Optional, Union
+
+
+class DatasetLoader(ABC):
+    def __init__(
+        self,
+        train_dataset_path: str,
+        queries_path: str,
+        ground_truth_path: str,
+        range: Optional[Tuple[int, int]] = None,
+    ) -> None:
+        """
+        Load benchmark dataset, queries and ground truth.
+        :param train_dataset_path: Path to the train dataset
+        :param queries_path: Path to the queries
+        :param ground_truth_path: Path to the ground truth
+        :param range: Number of elements to load from the dataset.
+                If a tuple is provided, the first element is the start index and
+                the second element is the end index
+        NOTE: The range parameter will only chunk the training dataset.
+
+        """
+        self.verify_paths([train_dataset_path, queries_path, ground_truth_path])
+        self.train_dataset_path = train_dataset_path
+        self.queries_path = queries_path
+        self.ground_truth_path = ground_truth_path
+
+        if range:
+            invalid_length = len(range) != 2
+            invalid_values = range[0] < 0 or range[1] < 0 or range[0] > range[1]
+            if invalid_length or invalid_values:
+                raise ValueError(f"Invalid range specified: {range}")
+
+        self.range = range
+
+    def verify_paths(self, paths: List[str]) -> None:
+        for path in paths:
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"File {path} not found")
+
+    @abstractmethod
+    def load_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        pass
+
+
+class NPYDatasetLoader(DatasetLoader):
+    def load_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if self.range:
+            start_index, end_index = self.range
+            train_dataset = np.load(self.train_dataset_path)[
+                start_index:end_index
+            ].astype(np.float32, copy=False)
+        else:
+            train_dataset = np.load(self.train_dataset_path).astype(
+                np.float32, copy=False
+            )
+        queries = np.load(self.queries_path).astype(np.float32, copy=False)
+        ground_truth = np.load(self.ground_truth_path).astype(np.int32, copy=False)
+        return train_dataset, queries, ground_truth
+
+
+class BVECDatasetLoader:
+    """
+    This is adapted from the Matlab code provided by the authors of the SIFT1M dataset.
+    Reference:
+        1. http://corpus-texmex.irisa.fr/ivecs_read.m
+        2. http://corpus-texmex.irisa.fr/bvecs_read.m
+    NOTE: This is mostly for loading the SIFT1B dataset.
+    """
+
+    def _read_ivecs_file(self, filename: str) -> np.ndarray:
+        with open(filename, "rb") as f:
+            dimension = np.fromfile(f, dtype=np.int32, count=1)[0]
+            vec_size = 4 + dimension * 4
+
+            f.seek(0, 2)
+            total_vectors = f.tell() // vec_size
+            start, end = 1, total_vectors
+
+            if self.range:
+                start, end = self.range
+                end = min(end, total_vectors)
+
+            assert 1 <= start <= end <= total_vectors, "Invalid range specified."
+
+            f.seek((start - 1) * vec_size, 0)
+            v = np.fromfile(
+                f, dtype=np.int32, count=(dimension + 1) * (end - start + 1)
+            )
+            return v.reshape((end - start + 1, dimension + 1))[:, 1:]
+
+    def _read_bvecs_file(self, filename: str) -> np.ndarray:
+        with open(filename, "rb") as f:
+            dimension = np.fromfile(f, dtype=np.int32, count=1)[0]
+            vec_size = 4 + dimension
+
+            f.seek(0, 2)
+            total_vectors = f.tell() // vec_size
+
+            start, end = 1, total_vectors
+            if self.range:
+                start, end = self.range
+                end = min(end, total_vectors)
+
+            assert 1 <= start <= end <= total_vectors, "Invalid range specified."
+
+            f.seek((start - 1) * vec_size, 0)
+            v = np.fromfile(
+                f, dtype=np.uint8, count=(dimension + 4) * (end - start + 1)
+            )
+            return v.reshape((end - start + 1, dimension + 4))[:, 4:]
+
+    def load_data(self) -> Tuple[np.ndarray]:
+        ground_truth = self._read_ivecs_file(self.gtruth_path, self.range)
+        # Ground truth has shape (10000, 1000) but we only need the first 100 queries
+        ground_truth = ground_truth[:100]
+
+        train_data = self._read_bvecs_file(self.train_dataset_path, self.range)
+        queries_data = self._read_bvecs_file(self.queries_path, self.range)
+
+        return train_data, queries_data, ground_truth
+
+
+class FBINDatasetLoader(DatasetLoader):
+    """
+    NOTE: This is mostly for loading the DEEP1B dataset.
+    Uses numpy's memmap to map the file to memory, which is useful for large files like the DEEP1B dataset.
+    """
+
+    def load_ground_truth(self, path: str) -> Tuple[np.ndarray, np.ndarray, int, int]:
+        """
+        Load the IDs and the distances of the top-k's and not the distances.
+        Returns:
+            - Array of top k IDs
+            - Array of top k distances
+            - Number of queries
+            - K value
+        """
+        with open(path, "rb") as f:
+            num_queries = np.fromfile(f, dtype=np.uint32, count=1)[0]
+            K = np.fromfile(f, dtype=np.uint32, count=1)[0]
+
+        # Memory-map the IDs only
+        ground_truth_ids = np.memmap(
+            path,
+            dtype=np.uint32,
+            mode="r",
+            shape=(num_queries, K),
+            offset=8,
+        )
+
+        ground_truth_dists = np.memmap(
+            path,
+            dtype=np.float32,
+            mode="r",
+            shape=(num_queries, K),
+            offset=8 + (num_queries * K * np.dtype(np.uint32).itemsize),
+        )
+
+        return ground_truth_ids, ground_truth_dists, num_queries, K
+
+    def load_data(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        # Read header information (num_points and num_dimensions)
+        with open(self.train_dataset_path, "rb") as f:
+            num_points = np.fromfile(f, dtype=np.uint32, count=1)[0]
+            num_dimensions = np.fromfile(f, dtype=np.uint32, count=1)[0]
+
+        if self.range:
+            start_index, end_index = self.range
+            if start_index < 0 or end_index > num_points or start_index >= end_index:
+                raise ValueError("Invalid range specified.")
+
+            chunk_size = end_index - start_index
+
+            # Calculate the bytes offset from the start of the file data (after header)
+            # Each point consists of num_dimensions floats, and each float is np.float32.itemsize (4) bytes
+            offset = 8 + start_index * num_dimensions * np.dtype(np.float32).itemsize
+
+            # Using np.memmap to map the chunk of the file
+            train_dataset = np.memmap(
+                self.train_dataset_path,
+                dtype=np.float32,
+                mode="r",
+                offset=offset,
+                shape=(chunk_size, num_dimensions),
+            )
+        else:
+            train_dataset = np.fromfile(
+                self.train_dataset_path, dtype=np.float32, offset=8
+            )
+            train_dataset = train_dataset.reshape((num_points, num_dimensions))
+
+        ground_truth, _, num_queries, _ = self.load_ground_truth(self.ground_truth_path)
+        queries_dataset = np.fromfile(
+            self.queries_path,
+            dtype=np.float32,
+            offset=8,
+        )
+        queries_dataset = queries_dataset.reshape((num_queries, num_dimensions))
+
+        return train_dataset, queries_dataset, ground_truth
+
+
+def get_data_loader(**kwargs) -> DatasetLoader:
+    """
+    Factory function for creating the appropriate dataset loader based on the extension of the training dataset.
+    :param kwargs: Dictionary of parameters. These must correspond to the parameters of the DatasetLoader class.
+    """
+    train_dataset_path = kwargs.get("train_dataset_path")
+    if not train_dataset_path:
+        raise ValueError("The train_dataset_path parameter is required.")
+
+    if train_dataset_path.endswith(".npy"):
+        return NPYDatasetLoader(**kwargs)
+    elif train_dataset_path.endswith(".bvecs"):
+        return BVECDatasetLoader(**kwargs)
+    elif train_dataset_path.endswith(".fbin"):
+        return FBINDatasetLoader(**kwargs)
+
+    raise ValueError("Invalid file extension for the training dataset.")

--- a/experiments/run-big-bench.py
+++ b/experiments/run-big-bench.py
@@ -6,6 +6,7 @@ import numpy as np
 from typing import Optional, Tuple, List, Dict
 import numpy as np
 import os
+import gc
 import logging
 import platform, socket, psutil
 import argparse
@@ -117,14 +118,8 @@ def create_and_train_hnsw_index(
     dataset_size: int,
     ef_construction: int,
     max_edges_per_node: int,
-    num_threads: int,
-    base_layer_filename: Optional[str] = None,
-) -> Union[hnswlib.Index, None]:
-    """
-    Kind of messy to return either a hnswlib.Index or None, but we are doing this so that
-    when we use the HNSW base layer to construct a Flatnav index, we don't ever have the
-    two indices in memory at the same time. This should help with memory usage.
-    """
+    num_threads,
+) -> hnswlib.Index:
     hnsw_index = hnswlib.Index(space=space, dim=dim)
     hnsw_index.init_index(
         max_elements=dataset_size, ef_construction=ef_construction, M=max_edges_per_node
@@ -135,10 +130,6 @@ def create_and_train_hnsw_index(
     hnsw_index.add_items(data=data, ids=np.arange(dataset_size))
     end = time.time()
     logging.info(f"Indexing time = {end - start} seconds")
-
-    if base_layer_filename:
-        hnsw_index.save_base_layer_graph(filename=base_layer_filename)
-        return None
 
     return hnsw_index
 
@@ -155,20 +146,6 @@ def train_index(
     hnsw_base_layer_filename: Optional[str] = None,
     num_build_threads: int = 1,
 ) -> Union[flatnav.index.L2Index, flatnav.index.IPIndex, hnswlib.Index]:
-    """
-    Creates and trains an index on the given dataset.
-    :param train_dataset: The dataset to train the index on.
-    :param distance_type: The distance type to use. Options include "l2" and "angular".
-    :param dim: The dimensionality of the dataset.
-    :param dataset_size: The number of points in the dataset.
-    :param max_edges_per_node: The maximum number of edges per node in the graph.
-    :param ef_construction: The size of the dynamic candidate list during construction.
-    :param index_type: The type of index to create. Options include "flatnav" and "hnsw".
-    :param use_hnsw_base_layer: If set, use HNSW's base layer's connectivity for the Flatnav index.
-    :param hnsw_base_layer_filename: Filename to save the HNSW base layer graph to.
-    :param num_build_threads: The number of threads to use during index construction.
-    :return: The trained index.
-    """
     if index_type == "hnsw":
         # We use "angular" instead of "ip", so here we are just converting.
         _distance_type = distance_type if distance_type == "l2" else "ip"
@@ -191,7 +168,7 @@ def train_index(
             raise ValueError("Must provide a filename for the HNSW base layer graph.")
 
         _distance_type = distance_type if distance_type == "l2" else "ip"
-        create_and_train_hnsw_index(
+        hnsw_index = create_and_train_hnsw_index(
             data=train_dataset,
             space=_distance_type,
             dim=dim,
@@ -199,10 +176,18 @@ def train_index(
             ef_construction=ef_construction,
             max_edges_per_node=max_edges_per_node // 2,
             num_threads=num_build_threads,
-            base_layer_filename=hnsw_base_layer_filename,
         )
+        
+        try:
+            # Now extract the base layer's graph and save it to a file.
+            # This will be a Matrix Market file that we use to construct the Flatnav index.
+            hnsw_index.save_base_layer_graph(filename=hnsw_base_layer_filename)
 
-        assert os.path.exists(hnsw_base_layer_filename)
+        finally:
+            # delete the HNSW index and force garbage collection
+            del hnsw_index
+            gc.collect()
+
         index = flatnav.index.index_factory(
             distance_type=distance_type,
             dim=dim,

--- a/experiments/run-big-bench.py
+++ b/experiments/run-big-bench.py
@@ -10,7 +10,6 @@ import logging
 import platform, socket, psutil
 import argparse
 import flatnav
-import gc 
 from plotting_utils import plot_qps_against_recall, plot_percentile_against_recall
 
 
@@ -207,8 +206,14 @@ def create_and_train_hnsw_index(
     dataset_size: int,
     ef_construction: int,
     max_edges_per_node: int,
-    num_threads,
-) -> hnswlib.Index:
+    num_threads: int,
+    base_layer_filename: Optional[str] = None,
+) -> Union[hnswlib.Index, None]:
+    """
+    Kind of messy to return either a hnswlib.Index or None, but we are doing this so that
+    when we use the HNSW base layer to construct a Flatnav index, we don't ever have the 
+    two indices in memory at the same time. This should help with memory usage.
+    """
     hnsw_index = hnswlib.Index(space=space, dim=dim)
     hnsw_index.init_index(
         max_elements=dataset_size, ef_construction=ef_construction, M=max_edges_per_node
@@ -219,6 +224,10 @@ def create_and_train_hnsw_index(
     hnsw_index.add_items(data=data, ids=np.arange(dataset_size))
     end = time.time()
     logging.info(f"Indexing time = {end - start} seconds")
+    
+    if base_layer_filename:
+        hnsw_index.save_base_layer_graph(filename=base_layer_filename)
+        return None
 
     return hnsw_index
 
@@ -235,6 +244,20 @@ def train_index(
     hnsw_base_layer_filename: Optional[str] = None,
     num_build_threads: int = 1,
 ) -> Union[flatnav.index.L2Index, flatnav.index.IPIndex, hnswlib.Index]:
+    """
+    Creates and trains an index on the given dataset.
+    :param train_dataset: The dataset to train the index on.
+    :param distance_type: The distance type to use. Options include "l2" and "angular".
+    :param dim: The dimensionality of the dataset.
+    :param dataset_size: The number of points in the dataset.
+    :param max_edges_per_node: The maximum number of edges per node in the graph.
+    :param ef_construction: The size of the dynamic candidate list during construction.
+    :param index_type: The type of index to create. Options include "flatnav" and "hnsw".
+    :param use_hnsw_base_layer: If set, use HNSW's base layer's connectivity for the Flatnav index.
+    :param hnsw_base_layer_filename: Filename to save the HNSW base layer graph to.
+    :param num_build_threads: The number of threads to use during index construction.
+    :return: The trained index.
+    """
     if index_type == "hnsw":
         # We use "angular" instead of "ip", so here we are just converting.
         _distance_type = distance_type if distance_type == "l2" else "ip"
@@ -257,7 +280,7 @@ def train_index(
             raise ValueError("Must provide a filename for the HNSW base layer graph.")
 
         _distance_type = distance_type if distance_type == "l2" else "ip"
-        hnsw_index = create_and_train_hnsw_index(
+        create_and_train_hnsw_index(
             data=train_dataset,
             space=_distance_type,
             dim=dim,
@@ -265,18 +288,10 @@ def train_index(
             ef_construction=ef_construction,
             max_edges_per_node=max_edges_per_node // 2,
             num_threads=num_build_threads,
+            base_layer_filename=hnsw_base_layer_filename,
         )
-
-        try:
-            # Now extract the base layer's graph and save it to a file.
-            # This will be a Matrix Market file that we use to construct the Flatnav index.
-            hnsw_index.save_base_layer_graph(filename=hnsw_base_layer_filename)
-            
-        finally:
-            # delete the HNSW index and force garbage collection
-            del hnsw_index
-            gc.collect()
-            
+        
+        assert os.path.exists(hnsw_base_layer_filename)
         index = flatnav.index.index_factory(
             distance_type=distance_type,
             dim=dim,


### PR DESCRIPTION
The `load_benchmark_dataset` was getting a bit hard to reason through, so I refactored it based on the different file types we've been using (`.npy`, `.bvecs`, and `fbin`). Each dataset loader class corresponds to a loader for each dataset type. 

The PR also makes it so that we can specify a desired range of data points to retrieve. We previously had a `chunk_size` parameter, but it was assuming that we always start from index 0. This change will make it easier to debug the Deep1B trap node weirdness. 