### PR TITLE
Fix Index Loading Function 

### DIFF
--- a/flatnav_python/python_bindings.cpp
+++ b/flatnav_python/python_bindings.cpp
@@ -288,13 +288,8 @@ void bindIndexMethods(
           },
           py::arg("filename"),
           "Save a FlatNav index at the given file location.")
-      .def_static(
-          "load",
-          [](const std::string &filename) {
-            return IndexType::loadIndex(filename);
-          },
-          py::arg("filename"),
-          "Load a FlatNav index from a given file location")
+      .def_static("load", &IndexType::loadIndex, py::arg("filename"),
+                  "Load a FlatNav index from a given file location")
       .def("add", &IndexType::add, py::arg("data"), py::arg("ef_construction"),
            py::arg("num_initializations") = 100, py::arg("labels") = py::none(),
            "Add vectors(data) to the index with the given `ef_construction` "


### PR DESCRIPTION
In our code, we had the following constructor for the `PyIndex` class:

```c++
  explicit PyIndex(std::unique_ptr<Index<dist_t, label_t>> index)
      : _dim(index->dataDimension()), _label_id(0), _verbose(false),
        _index(index.release()) {

    if (_verbose) {
      _index->getIndexSummary();
    }
  }
```

which is called during loading

```c++
  static std::unique_ptr<PyIndex<dist_t, label_t>>
  loadIndex(const std::string &filename) {
    auto index = Index<dist_t, label_t>::loadIndex(/* filename = */ filename);
    return std::make_unique<PyIndex<dist_t, label_t>>(std::move(index));
  }
```

The problem would occur on the line `std::make_unique<PyIndex<dist_t, label_t>>(std::move(index));`

Here is why: 
* In the `Index` class, we define a custom [destructor](https://github.com/BlaiseMuhirwa/flatnav-experimental/blob/f2293747da0db631637f0174388e20aace697e12/flatnav/Index.h#L137). 
* [The rule of 5](https://en.cppreference.com/w/cpp/language/rule_of_three) in C++ tells us that if you've defined a custom destructor, the move constructor and move assignment operator won't be defined by default. 
* Without an implicitly defined move constructor, `std::move(index)` actually defaults to a copy constructor. You don't get an error, but the call becomes super expensive. This is problematic on billion-scale because we can't afford to copy such a large object if we only want to move it instead. 

This PR explicitly defines a move constructor and move assignment operator. These actually need to be explicit because the default move constructor cannot ensure that the allocated memory is safely transferred and the source object is left in a valid state. That is, the following code might hide a memory leak

```c++
Index(Index &&other) = default;
```

Also, to be safe, I'm deleting the copy constructor and the copy assignment operator. 


