### PR TITLE
Terminate supervisord process

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -14,7 +14,9 @@ stderr_logfile=/var/log/cron_stderr.log
 
 
 [program:benchmark-runner]
-command=make "%(ENV_MAKE_TARGET)s"
+# Terminate the supervisor process once benchmark-runner process exits. kill -s SIGTERM 1 will kill 
+# the process with PID 1, which is supervisord in the docker container. 
+command=/bin/bash -c "make '%(ENV_MAKE_TARGET)s'; echo 'Make completed'; kill -s SIGTERM 1"
 autostart=true
 autorestart=false
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
We were having to ctrl + c to terminate the supervisord process that's executing the make command. This makes it so that once make exits, we immediately also terminate the supervisord process. 