### PR TITLE
Fix small regression in the neighbor selection heuristic.

### DIFF
--- a/flatnav/index/Index.h
+++ b/flatnav/index/Index.h
@@ -357,7 +357,7 @@ class Index {
         /* query = */ data, /* entry_node = */ entry_node,
         /* buffer_size = */ ef_construction);
 
-    int selection_M = std::min(_M / 2, 1);
+    int selection_M = std::max(_M / 2, 1);
     selectNeighbors(/* neighbors = */ neighbors, /* M = */ selection_M);
     connectNeighbors(neighbors, new_node_id);
   }

--- a/flatnav/index/Index.h
+++ b/flatnav/index/Index.h
@@ -768,8 +768,8 @@ class Index {
             candidates.emplace(distance, label);
           }
         }
-        int connection_M = _M;  // 2X larger than the previous call to selectNeighbors.
-        selectNeighbors(candidates, connection_M);
+        // 2X larger than the previous call to selectNeighbors.
+        selectNeighbors(candidates, _M);
         // connect the pruned set of candidates, including self-loops:
         size_t j = 0;
         while (candidates.size() > 0) {  // candidates

--- a/flatnav/index/Index.h
+++ b/flatnav/index/Index.h
@@ -357,7 +357,8 @@ class Index {
         /* query = */ data, /* entry_node = */ entry_node,
         /* buffer_size = */ ef_construction);
 
-    selectNeighbors(/* neighbors = */ neighbors);
+    int selection_M = std::min(_M / 2, 1);
+    selectNeighbors(/* neighbors = */ neighbors, /* M = */ selection_M);
     connectNeighbors(neighbors, new_node_id);
   }
 
@@ -672,14 +673,14 @@ class Index {
    * heuristic. The neighbors priority queue contains elements sorted by
    * distance where the top element is the furthest neighbor from the query.
    */
-  void selectNeighbors(PriorityQueue& neighbors) {
-    if (neighbors.size() < _M) {
+  void selectNeighbors(PriorityQueue& neighbors, int M) {
+    if (neighbors.size() < M) {
       return;
     }
 
     PriorityQueue candidates;
     std::vector<dist_node_t> saved_candidates;
-    saved_candidates.reserve(_M);
+    saved_candidates.reserve(M);
 
     while (neighbors.size() > 0) {
       candidates.emplace(-neighbors.top().first, neighbors.top().second);
@@ -688,7 +689,7 @@ class Index {
 
     float cur_dist = 0.0;
     while (candidates.size() > 0) {
-      if (saved_candidates.size() >= _M) {
+      if (saved_candidates.size() >= M) {
         break;
       }
       // Extract the closest element from candidates.
@@ -767,7 +768,8 @@ class Index {
             candidates.emplace(distance, label);
           }
         }
-        selectNeighbors(candidates);
+        int connection_M = _M;  // 2X larger than the previous call to selectNeighbors.
+        selectNeighbors(candidates, connection_M);
         // connect the pruned set of candidates, including self-loops:
         size_t j = 0;
         while (candidates.size() > 0) {  // candidates

--- a/flatnav/index/Index.h
+++ b/flatnav/index/Index.h
@@ -357,7 +357,7 @@ class Index {
         /* query = */ data, /* entry_node = */ entry_node,
         /* buffer_size = */ ef_construction);
 
-    int selection_M = std::max(_M / 2, 1);
+    int selection_M = std::max(static_cast<int>(_M / 2), 1);
     selectNeighbors(/* neighbors = */ neighbors, /* M = */ selection_M);
     connectNeighbors(neighbors, new_node_id);
   }


### PR DESCRIPTION
I examined the graph construction step-by-step, by dumping the graph constructed by hnswlib and the graph constructed by flatnav, for SIFT1M. Surprisingly, there were significant differences in the first 100 points.

For example, here is the graph built by HNSW after 20 node additions. The graph dump is formatted by "node ID: out-degree list."

```
HNSW Graph
0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
1 0 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17
2 1 0 3 4 5 6 7 8 9 10 11 12 13 14 15
3 0 1 2 4 5 6 7 8 9 10 11 12 13 14 15 18 19
4 3 0 1 2 5 6 7 8 9 10 11 12 13 14 15
5 0 2 3 1 4 6 7 8 9 10 11 12 13 14 15
6 3 0 2 5 1 4 7 8 9 10 11 12 13 14 15
7 3 0 1 2 5 6 4 8 9 10 11 12 13 14 15 19
8 0 2 3 6 7 1 5 4 9 10 11 12 13 14 15
9 8 5 6 4 0 1 3 2 7 10 11 12 13 14 15 16
10 8 5 6 4 0 3 7 2 1 9 11 12 13 14 15
11 0 10 9 3 2 4 1 5 8 7 6 12 13 14 15
12 11 8 6 4 7 5 1 3 2 0 10 9 13 14 15 17 18 19
13 5 8 0 6 11 3 4 7 2 1 12 10 9 14 15 16 19
14 8 11 6 4 5 0 3 7 2 1 12 13 9 10 15 17
15 8 3 5 0 4 11 6 2 7 1 12 10 13 9 14 16 17
16 1 9 15 13
17 1 12 15 14 18
18 3 17 12
19 3 7 12 13
```

And here is the graph built by FlatNav after the same 20 node additions.
```
0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
1 0 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
2 1 0 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
3 0 1 2 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
4 3 0 1 2 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
5 0 2 3 1 4 6 7 8 9 10 11 12 13 14 15 16 17 18 19
6 3 0 2 5 1 4 7 8 9 10 11 12 13 14 15 16 17 18 19
7 3 0 1 2 5 6 4 8 9 10 11 12 13 14 15 16 17 18 19
8 0 2 3 6 7 1 5 4 9 10 11 12 13 14 15 16 17 18 19
9 8 5 6 4 0 1 3 2 7 10 11 12 13 14 15 16 17 18 19
10 8 5 6 4 0 3 7 2 1 9 11 12 13 14 15 16 17 18 19
11 0 10 9 3 2 4 1 5 8 7 6 12 13 14 15 16 17 18 19
12 11 8 6 4 7 5 1 3 2 0 10 9 13 14 15 16 17 18 19
13 5 8 0 6 11 3 4 7 2 1 12 10 9 14 15 16 17 18 19
14 8 11 6 4 5 0 3 7 2 1 12 13 9 10 15 16 17 18 19
15 8 3 5 0 4 11 6 2 7 1 12 10 13 9 14 16 17 18 19
16 8 5 11 4 0 6 3 7 2 1 10 12 14 9 15 13 17 18 19
17 8 11 6 4 0 5 3 7 2 1 12 9 13 16 15 10 14 18 19
18 6 11 4 8 0 2 7 5 3 1 9 10 15 13 14 16 17 12 19
19 8 0 5 11 4 6 3 2 1 7 10 14 17 9 15 18 12 16 13
```

The reason for this difference in behavior is that HNSW uses different buffer sizes for the neighbor selection heuristic. In the first call to the heuristic, HNSW selects `_M` neighbors from the beam search results. In the second call (which occurs inside the logic that mutually connects a new point with its neighbors), HNSW uses `2 * _M` - the full out-degree.

To help explain the code, note that `getNeighborsByHeuristic2` in the hnswlib implementation is the same as `selectNeighbors` in the FlatNav implementation. Also, `mutuallyConnectNewElement` in HNSW corresponds to `connectNeighbors` inside FlatNav.

The fix is to call `selectNeighbors` with `M // 2` the first time and `M` the second time in FlatNav. This causes the construction processes to build the same graphs, as expected (checked at 1K additions with SIFT1M).